### PR TITLE
코인상세페이지 진입 시 필요한 뷰모델 dependency 생성

### DIFF
--- a/CryptocurrencyExchange/CryptocurrencyExchange.xcodeproj/project.pbxproj
+++ b/CryptocurrencyExchange/CryptocurrencyExchange.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		B4471E6627CFBE5100668B64 /* ChartViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B4471E6427CFBE5100668B64 /* ChartViewController.xib */; };
 		B4471E6827CFBE5F00668B64 /* ChartsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4471E6727CFBE5F00668B64 /* ChartsViewModel.swift */; };
 		B4471E6A27CFC3ED00668B64 /* CoinDetailsTopTabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4471E6927CFC3ED00668B64 /* CoinDetailsTopTabs.swift */; };
+		B4498D6827D63A4A00F9B2CE /* CoinDetailsDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4498D6727D63A4A00F9B2CE /* CoinDetailsDependency.swift */; };
 		B467102F27CA8A1600A11C3F /* ViewControllerInNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B467102E27CA8A1600A11C3F /* ViewControllerInNavigation.swift */; };
 		B498EF4927C8DC6600C8F5FC /* ExchangeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B498EF4827C8DC6600C8F5FC /* ExchangeViewModel.swift */; };
 		B4BC4E8F27CDF70900DE19EC /* CoinDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4BC4E8D27CDF70900DE19EC /* CoinDetailViewController.swift */; };
@@ -193,6 +194,7 @@
 		90E12EB427D335AF00373FF9 /* OrderbookViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OrderbookViewController.xib; sourceTree = "<group>"; };
 		92774D2EEF35C757FAE75845 /* Pods_CryptocurrencyExchange.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CryptocurrencyExchange.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B1F4A9C36FC00016C5418E89 /* Pods-CryptocurrencyExchange.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CryptocurrencyExchange.release.xcconfig"; path = "Target Support Files/Pods-CryptocurrencyExchange/Pods-CryptocurrencyExchange.release.xcconfig"; sourceTree = "<group>"; };
+		B4498D6727D63A4A00F9B2CE /* CoinDetailsDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailsDependency.swift; sourceTree = "<group>"; };
 		B467102E27CA8A1600A11C3F /* ViewControllerInNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerInNavigation.swift; sourceTree = "<group>"; };
 		B498EF4827C8DC6600C8F5FC /* ExchangeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExchangeViewModel.swift; sourceTree = "<group>"; };
 		B4BC4E8D27CDF70900DE19EC /* CoinDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoinDetailViewController.swift; sourceTree = "<group>"; };
@@ -557,6 +559,7 @@
 		B4471E6C27CFCF8A00668B64 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				B4498D6727D63A4A00F9B2CE /* CoinDetailsDependency.swift */,
 				B4471E6927CFC3ED00668B64 /* CoinDetailsTopTabs.swift */,
 			);
 			path = Model;
@@ -1277,6 +1280,7 @@
 				FFB2EFB427D05F0D00944E97 /* CrypotocurrencyListTableViewEntity.swift in Sources */,
 				FF19E29827C9FB6D00DBD52D /* WebSoketType.swift in Sources */,
 				B4471E6127CFBDD600668B64 /* QuoteViewModel.swift in Sources */,
+				B4498D6827D63A4A00F9B2CE /* CoinDetailsDependency.swift in Sources */,
 				B4471E6827CFBE5F00668B64 /* ChartsViewModel.swift in Sources */,
 				9B778C6A27CF31C20009D343 /* BithumbCandleStickDataSet.swift in Sources */,
 				9B778C6527CF14350009D343 /* Observable.swift in Sources */,

--- a/CryptocurrencyExchange/CryptocurrencyExchange/CoinDetails/Model/CoinDetailsDependency.swift
+++ b/CryptocurrencyExchange/CryptocurrencyExchange/CoinDetails/Model/CoinDetailsDependency.swift
@@ -1,0 +1,13 @@
+//
+//  CoinDetailsDependency.swift
+//  CryptocurrencyExchange
+//
+//  Created by Dayeon Jung on 2022/03/07.
+//
+
+import Foundation
+
+struct CoinDetailsDependency {
+    var orderCurrency: String
+    var paymentCurrency: String
+}

--- a/CryptocurrencyExchange/CryptocurrencyExchange/CoinDetails/ViewModel/CoinDetailsViewModel.swift
+++ b/CryptocurrencyExchange/CryptocurrencyExchange/CoinDetails/ViewModel/CoinDetailsViewModel.swift
@@ -9,8 +9,13 @@ import Foundation
 
 class CoinDetailsViewModel: XIBInformation {
     var nibName: String?
+    var dependency: CoinDetailsDependency
     
-    init(nibName: String?) {
+    init(
+        nibName: String?,
+        dependency: CoinDetailsDependency
+    ) {
         self.nibName = nibName
+        self.dependency = dependency
     }
 }

--- a/CryptocurrencyExchange/CryptocurrencyExchange/Common/TabBar/TabBarController.swift
+++ b/CryptocurrencyExchange/CryptocurrencyExchange/Common/TabBar/TabBarController.swift
@@ -48,7 +48,11 @@ class TabBarController: UITabBarController {
     var coindDetailsViewController: ViewControllerInNavigation = {
         let coinDetailViewController = CoinDetailsViewController(
             viewModel: CoinDetailsViewModel(
-                nibName: "CoinDetailsViewController"
+                nibName: "CoinDetailsViewController",
+                dependency: CoinDetailsDependency(
+                    orderCurrency: "BTC",
+                    paymentCurrency: "KRW"
+                )
             )
         )
         


### PR DESCRIPTION
CoinDetailsViewController 진입 시 필요한 dependency 모델을 생성하였습니다.

```
let coinDetailViewController = CoinDetailsViewController(
             viewModel: CoinDetailsViewModel(
                 nibName: "CoinDetailsViewController",
                 dependency: CoinDetailsDependency(
                     orderCurrency: "BTC",
                     paymentCurrency: "KRW"
                 )
             )
         )
```
와 같이 "BTC", "KRW" 를 해당하는 값에 맞게 넣어 뷰컨트롤러를 push 해주시면 됩니다!

@p41155a
TabBarController를 참고해주시고,
완성되면 TabBarController에 설정해주었던 부분은 없애주시면 감사하겠습니다!

@derrickkim0109 과 저는 
CoinDetailsViewController 내의 viewModel에 정의한 `orderCurrency`와 `paymentCurrency`에 접근하여,
API 호출 시 사용하면 됩니다!